### PR TITLE
Temp to support Mozilla Common Voice dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 synthesizer/saved_models/*
 vocoder/saved_models/*
 !vocoder/saved_models/pretrained/*
+.vscode/settings.json
+.DS_Store

--- a/pre.py
+++ b/pre.py
@@ -12,14 +12,14 @@ import argparse
 recognized_datasets = [
     "aidatatang_200zh",
     "magicdata",
-    "aishell3"
+    "aishell3",
+    "mozilla"
 ]
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Preprocesses audio files from datasets, encodes them as mel spectrograms "
-                    "and writes them to  the disk. Audio files are also saved, to be used by the "
-                    "vocoder for training.",
+        "and writes them to  the disk. Audio files are also saved, to be used by the "
+        "vocoder for training.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument("datasets_root", type=Path, help=\
@@ -64,9 +64,9 @@ if __name__ == "__main__":
                 "use --no_trim to disable this error message.")
     encoder_model_fpath = args.encoder_model_fpath
     del args.no_trim, args.encoder_model_fpath
-   
+
     args.hparams = hparams.parse(args.hparams)
 
     preprocess_dataset(**vars(args))
-    
-    create_embeddings(synthesizer_root=args.out_dir, n_processes=args.n_processes, encoder_model_fpath=encoder_model_fpath)    
+
+    create_embeddings(synthesizer_root=args.out_dir, n_processes=args.n_processes, encoder_model_fpath=encoder_model_fpath)

--- a/synthesizer/preprocess_speaker.py
+++ b/synthesizer/preprocess_speaker.py
@@ -10,6 +10,12 @@ from pypinyin.contrib.neutral_tone import NeutralToneWith5Mixin
 from pypinyin.converter import DefaultConverter
 from pypinyin.core import Pinyin
 
+import warnings
+
+# Ignore librosa warning message when processing mp3
+warnings.filterwarnings("ignore")
+
+
 class PinyinConverter(NeutralToneWith5Mixin, DefaultConverter):
     pass
 
@@ -22,15 +28,15 @@ def _process_utterance(wav: np.ndarray, text: str, out_dir: Path, basename: str,
     # For you not to lose your head if you ever wish to change things here or implement your own
     # synthesizer.
     # - Both the audios and the mel spectrograms are saved as numpy arrays
-    # - There is no processing done to the audios that will be saved to disk beyond volume  
+    # - There is no processing done to the audios that will be saved to disk beyond volume
     #   normalization (in split_on_silences)
     # - However, pre-emphasis is applied to the audios before computing the mel spectrogram. This
     #   is why we re-apply it on the audio on the side of the vocoder.
     # - Librosa pads the waveform before computing the mel spectrogram. Here, the waveform is saved
     #   without extra padding. This means that you won't have an exact relation between the length
     #   of the wav and of the mel spectrogram. See the vocoder data loader.
-    
-    
+
+
     # Skip existing utterances if needed
     mel_fpath = out_dir.joinpath("mels", "mel-%s.npy" % basename)
     wav_fpath = out_dir.joinpath("audio", "audio-%s.npy" % basename)
@@ -40,31 +46,31 @@ def _process_utterance(wav: np.ndarray, text: str, out_dir: Path, basename: str,
     # Trim silence
     if hparams.trim_silence:
         wav = encoder.preprocess_wav(wav, normalize=False, trim_silence=True)
-    
+
     # Skip utterances that are too short
     if len(wav) < hparams.utterance_min_duration * hparams.sample_rate:
         return None
-    
+
     # Compute the mel spectrogram
     mel_spectrogram = audio.melspectrogram(wav, hparams).astype(np.float32)
     mel_frames = mel_spectrogram.shape[1]
-    
+
     # Skip utterances that are too long
     if mel_frames > hparams.max_mel_frames and hparams.clip_mels_length:
         return None
-    
+
     # Write the spectrogram, embed and audio to disk
     np.save(mel_fpath, mel_spectrogram.T, allow_pickle=False)
     np.save(wav_fpath, wav, allow_pickle=False)
-    
+
     # Return a tuple describing this training example
     return wav_fpath.name, mel_fpath.name, "embed-%s.npy" % basename, len(wav), mel_frames, text
- 
+
 
 def _split_on_silences_aidatatang_200zh(wav_fpath, words, hparams):
     # Load the audio waveform
     wav, _ = librosa.load(wav_fpath, hparams.sample_rate)
-    wav = librosa.effects.trim(wav, top_db= 40, frame_length=2048, hop_length=512)[0]
+    wav = librosa.effects.trim(wav, top_db=40, frame_length=2048, hop_length=512)[0]
     if hparams.rescale:
         wav = wav / np.abs(wav).max() * hparams.rescaling_max
     # denoise, we may not need it here.
@@ -80,15 +86,20 @@ def _split_on_silences_aidatatang_200zh(wav_fpath, words, hparams):
 
     return wav, res
 
-def preprocess_speaker_general(speaker_dir, out_dir: Path, skip_existing: bool, hparams, dict_info, no_alignments: bool):
+def preprocess_speaker_general(speaker_dir, out_dir: Path, skip_existing: bool, hparams, dict_info, no_alignments: bool, is_tsv: bool):
     metadata = []
-    wav_fpath_list = speaker_dir.glob("*.wav")
+    if is_tsv:
+        wav_fpath_list = [speaker_dir]
+    else:
+        wav_fpath_list = speaker_dir.glob("*.wav")
+
     # Iterate over each wav
     for wav_fpath in wav_fpath_list:
         words = dict_info.get(wav_fpath.name.split(".")[0])
-        words = dict_info.get(wav_fpath.name) if not words else words # try with wav 
+        words = dict_info.get(wav_fpath.name) if not words else words  # try with wav
         if not words:
-            print("no wordS")
+            # TODO: In Mozilla Common Voice, there is only one `clips` folder for all train / test / validate mp3, so it would print "no wordS" frequently since it couldn't find value in train data.
+            #print("no wordS", wav_fpath.name)
             continue
         sub_basename = "%s_%02d" % (wav_fpath.name, 0)
         wav, text = _split_on_silences_aidatatang_200zh(wav_fpath, words, hparams)


### PR DESCRIPTION
You **HAVE TO** rename Mozilla Common Voice to the below data structure

- {dataset_name}/
- - zh-TW/
- - - clips/
- - - - xxx.mp3
- - - xxx.tsv

* TODO: Currently only support `train.tsv`, will also support other data like `test.tsv` or `validate.tsv` in the future
* TODO: Fix "no wordS" error when processing Mozilla Common Voice (cause only `train.tsv` for now)