### PR TITLE
Fix TypeError at line 459 in toolbox/ui.py when both PySide6(PyQt6) and PyQt5 installed

### DIFF
--- a/toolbox/ui.py
+++ b/toolbox/ui.py
@@ -1,9 +1,9 @@
-import matplotlib.pyplot as plt
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.figure import Figure
 from PyQt5.QtCore import Qt, QStringListModel
 from PyQt5 import QtGui
 from PyQt5.QtWidgets import *
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
 from encoder.inference import plot_embedding_as_heatmap
 from toolbox.utterance import Utterance
 from pathlib import Path


### PR DESCRIPTION
### Error Info Screenshot
![](https://cdn.jsdelivr.net/gh/CrystalRays/CDN@main/img/16389623959301638962395845.png)

### Error Reason
Matplotlib.backends.qt_compat.py decide the version of qt library according to sys.modules firstly, os.environ secondly and the sequence of PyQt6, PySide6, PyQt5, PySide 2 and etc finally. Import PyQt5 after matplotlib make that there is no PyQt5 in sys.modules so that it choose PyQt6 or PySide6 before PyQt5 if it installed.
因为Matplotlib.backends.qt_compat.py优先根据导入的库决定要使用的Python Qt的库，如果没有导入则根据环境变量PYQT_APT决定，再不济就按照PyQt6, PySide6, PyQt5, PySide 2的顺序导入已经安装的库。因为ui.py先导入matplotlib而不是PYQT5导致matplotlib在导入的库里找不到Qt的库，又没有指定环境变量，然后用户安装了Qt6的库的话就导入Qt6的库去了