### PR TITLE
Fix a UserWarning

### DIFF
--- a/synthesizer/synthesizer_dataset.py
+++ b/synthesizer/synthesizer_dataset.py
@@ -73,6 +73,7 @@ def collate_synthesizer(batch):
 
     # Speaker embedding (SV2TTS)
     embeds = [x[2] for x in batch]
+    embeds = np.stack(embeds)
 
     # Index (for vocoder preprocessing)
     indices = [x[3] for x in batch]


### PR DESCRIPTION
Fix a UserWarning in synthesizer/synthesizer_dataset.py, because of converting list of numpy array to torch tensor at Ln.85.