### PR TITLE
修复demo_tools加载aidatatang_200zh数据集的问题

### DIFF
--- a/toolbox/__init__.py
+++ b/toolbox/__init__.py
@@ -39,8 +39,7 @@ recognized_datasets = [
     "VoxCeleb2/dev/aac",
     "VoxCeleb2/test/aac",
     "VCTK-Corpus/wav48",
-    "aidatatang_200zh/corpus/dev",
-    "aidatatang_200zh/corpus/test",
+    "aidatatang_200zh/corpus",
     "aishell3/test/wav",
     "magicdata/train",
 ]


### PR DESCRIPTION
在使用demo_tools -d 加载数据集时发现一个问题：

- aidatatang_200zh标准数据集是不包含wav文件的（被打包在压缩包中），而demo_tools读取源音频是遍历目录下所有wav
- 在制作个人数据集时我们会把wav放在aidatatang_200zh/corpus/train/中
- 现在读取的目录只有“aidatatang_200zh\corpus\dev”和“aidatatang_200zh\corpus\test”

所以要不就干脆识别aidatatang_200zh\corpus吧